### PR TITLE
call checking against BWA more robust, lots of testing to do

### DIFF
--- a/perl/lib/Sanger/CGP/Pindel/OutputGen/CombinedRecordGenerator.pm
+++ b/perl/lib/Sanger/CGP/Pindel/OutputGen/CombinedRecordGenerator.pm
@@ -41,6 +41,7 @@ use base qw(Sanger::CGP::Pindel::OutputGen::PindelRecordParser);
 
 use Const::Fast qw(const);
 
+const my $F_PROPERPAIR  => 2;
 const my $F_UNMAPPED    => 4;
 const my $F_NOT_PRIMARY => 256;
 const my $F_QC_FAIL     => 512;
@@ -262,6 +263,7 @@ sub _read_depth {
 
 sub _read_filter {
   my $flag = shift->flag;
+	return 0 if(($flag | $F_PROPERPAIR) != $flag); # not properly paired
   for my $test(@FILTER_READS_IF_FLAG) {
     return 0 if(($flag | $test) == $flag);
   }

--- a/perl/lib/Sanger/CGP/Pindel/OutputGen/CombinedRecordGenerator.pm
+++ b/perl/lib/Sanger/CGP/Pindel/OutputGen/CombinedRecordGenerator.pm
@@ -41,7 +41,6 @@ use base qw(Sanger::CGP::Pindel::OutputGen::PindelRecordParser);
 
 use Const::Fast qw(const);
 
-const my $F_PROPERPAIR  => 2;
 const my $F_UNMAPPED    => 4;
 const my $F_NOT_PRIMARY => 256;
 const my $F_QC_FAIL     => 512;
@@ -263,7 +262,6 @@ sub _read_depth {
 
 sub _read_filter {
   my $flag = shift->flag;
-	return 0 if(($flag | $F_PROPERPAIR) != $flag); # not properly paired
   for my $test(@FILTER_READS_IF_FLAG) {
     return 0 if(($flag | $test) == $flag);
   }

--- a/perl/lib/Sanger/CGP/Pindel/OutputGen/CombinedRecordGenerator.pm
+++ b/perl/lib/Sanger/CGP/Pindel/OutputGen/CombinedRecordGenerator.pm
@@ -295,10 +295,15 @@ sub _count_sam_event_reads{
 
 	# These will be used by the pileup callback.
 	my $g_r_start = $record->range_start;
-	my $g_r_end = $record->range_end-1; # as indels are always attached to the base before in Bio::DB::HTS
-	my $g_chg_len = $record->type eq 'D' ? length $record->ref_seq : length $record->alt_seq;
-	my $g_min_chg_len = length $record->min_change;
-	$g_min_chg_len = 0 unless(defined $g_min_chg_len);
+	my ($g_r_end, $g_chg_len);
+	if($record->type eq 'D') {
+		$g_chg_len = length $record->ref_seq;
+		$g_r_end = $record->range_end - $g_chg_len;
+	}
+	else {
+		$g_r_end = $record->range_end-1; # as indels are always attached to the base before in Bio::DB::HTS
+		$g_chg_len = length $record->alt_seq;
+	}
 
 	my $chr = $record->chro;
 
@@ -325,7 +330,7 @@ sub _count_sam_event_reads{
 					$abs = abs $value;
 
 					##TODO WE SHOULD LOOK AT MATCHING ON CHANGE rather than length????????????? jwh
-					if($abs == $g_chg_len || $abs == $g_min_chg_len) {
+					if($abs == $g_chg_len) {
 						$strand_index = $a->reversed == 1 ? 0 : 1;
 
 						if($value > 0) {


### PR DESCRIPTION
We have identified a small number of incidents where the calls for a sample exceed the depth.

This has been isolated to a long standing bug (at least since moving the repo public), relating to attempting to align BWA calls to the pindel calls in regions of repeat, particularly where the pindel event is multiple repeat elements.

Example shown is of a pindel deletion of 8bp, that can be considered a repeat of 2x 4bp elements.  Searching for a smaller sub element is not valid as the pindel would call that as a separate event.

![misclassification](https://user-images.githubusercontent.com/3740323/146412013-c272473a-b907-4041-b12f-b0071fc0cf4b.png)
